### PR TITLE
Bugfix: Unknown column 'i.question' in getByTag()

### DIFF
--- a/backend/modules/projects/engine/model.php
+++ b/backend/modules/projects/engine/model.php
@@ -205,7 +205,7 @@ class BackendProjectsModel
 	public static function getByTag($tagId)
 	{
 		$items = (array) BackendModel::getContainer()->get('database')->getRecords(
-			'SELECT i.id AS url, i.question, mt.module
+			'SELECT i.id AS url, i.title AS name, mt.module
 			 FROM modules_tags AS mt
 			 INNER JOIN tags AS t ON mt.tag_id = t.id
 			 INNER JOIN projects AS i ON mt.other_id = i.id


### PR DESCRIPTION
Bugfix: Column not found, Unknown column 'i.question' in 'field list' in BackendProjectsModel::getByTag()

When do we get this error?
Backend > Modules > Tags > [select a tag] > Edit > error

(this bug is also in the faq module)
