### PR TITLE
Capitalize action names

### DIFF
--- a/src/Backend/Modules/Projects/Actions/Categories.php
+++ b/src/Backend/Modules/Projects/Actions/Categories.php
@@ -62,13 +62,13 @@ class Categories extends BackendBaseActionIndex
 		$this->dataGrid->setPaging(false);
 
 		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('index'))
+		if(BackendAuthentication::isAllowedAction('Index'))
 		{
 			$this->dataGrid->setColumnFunction(array(__CLASS__, 'setClickableCount'), array('[num_items]', BackendModel::createURLForAction('index') . '&amp;category=[id]'), 'num_items', true);
 		}
 
 		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('edit_category'))
+		if(BackendAuthentication::isAllowedAction('EditCategory'))
 		{
 			$this->dataGrid->setColumnURL('title', BackendModel::createURLForAction('edit_category') . '&amp;id=[id]');
 			$this->dataGrid->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_category') . '&amp;id=[id]', BL::lbl('Edit'));
@@ -85,7 +85,7 @@ class Categories extends BackendBaseActionIndex
 		$this->tpl->assign('dataGrid', ($this->dataGrid->getNumResults() != 0) ? $this->dataGrid->getContent() : false);
 
 		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('add_category') && $this->multipleCategoriesAllowed)
+		if(BackendAuthentication::isAllowedAction('AddCategory') && $this->multipleCategoriesAllowed)
 		{
 			$this->tpl->assign('showProjectsAddCategory', true);
 		}

--- a/src/Backend/Modules/Projects/Actions/EditCategory.php
+++ b/src/Backend/Modules/Projects/Actions/EditCategory.php
@@ -76,7 +76,7 @@ class EditCategory extends BackendBaseActionEdit
 
 		// assign the data
 		$this->tpl->assign('item', $this->record);
-		$this->tpl->assign('showProjectsDeleteCategory', BackendProjectsModel::deleteCategoryAllowed($this->id) && BackendAuthentication::isAllowedAction('delete_category'));
+		$this->tpl->assign('showProjectsDeleteCategory', BackendProjectsModel::deleteCategoryAllowed($this->id) && BackendAuthentication::isAllowedAction('DeleteCategory'));
 	}
 
 	/**

--- a/src/Backend/Modules/Projects/Actions/EditClient.php
+++ b/src/Backend/Modules/Projects/Actions/EditClient.php
@@ -80,7 +80,7 @@ class EditClient extends BackendBaseActionEdit
 
 		// assign the data
 		$this->tpl->assign('item', $this->record);
-		$this->tpl->assign('showProjectsDeleteClient', BackendProjectsModel::deleteClientAllowed($this->id) && BackendAuthentication::isAllowedAction('delete_client'));
+		$this->tpl->assign('showProjectsDeleteClient', BackendProjectsModel::deleteClientAllowed($this->id) && BackendAuthentication::isAllowedAction('DeleteClient'));
 	}
 
 	/**

--- a/src/Backend/Modules/Projects/Actions/Index.php
+++ b/src/Backend/Modules/Projects/Actions/Index.php
@@ -70,7 +70,7 @@ class Index extends BackendBaseActionIndex
 			$dataGrid->setRowAttributes(array('client' => '[client_id]'));
 			
 			// check if this action is allowed
-			if(BackendAuthentication::isAllowedAction('edit'))
+			if(BackendAuthentication::isAllowedAction('Edit'))
 			{
 				$dataGrid->addColumn('media', null, BL::lbl('Media'), BackendModel::createURLForAction('media') . '&amp;id=[id]', BL::lbl('Media'));
 				$dataGrid->setColumnFunction(array(__CLASS__, 'setMediaLink'), array('[id]'), 'media');


### PR DESCRIPTION
Without capitals the backend actions were only visible for god users.
With capitals they are visible for all groups.